### PR TITLE
Ensure twice quoted ansible_distribution is correctly detected

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,18 @@
 ---
+
+- set_fact: ansible_distribution="{{ansible_distribution|lower|replace('\"', '')}}"
+
 - name: gather os specific variables
   include_vars: "{{ item }}"
   with_first_found:
     - files:
-      - "{{ ansible_distribution|lower }}-{{
+      - "{{ ansible_distribution }}-{{
             ansible_distribution_version|lower|replace('/', '_') }}.yml"
-      - "{{ ansible_distribution|lower }}-{{
+      - "{{ ansible_distribution }}-{{
             ansible_distribution_release }}.yml"
-      - "{{ ansible_distribution|lower }}-{{
+      - "{{ ansible_distribution }}-{{
             ansible_distribution_major_version|lower|replace('/', '_') }}.yml"
-      - "{{ ansible_distribution|lower }}.yml"
+      - "{{ ansible_distribution }}.yml"
       - "{{ ansible_os_family|lower }}.yml"
       - defaults.yml
       paths:


### PR DESCRIPTION
Hi!

I've encounteted a weird issue and here's a quick fix. On some of Debian machines, Ansible returns `ansible_distribution` fact quoted twice, e.g: 
```
TASK: [common | debug var=ansible_distribution] ******************************* 
ok: [solaris] => {
    "var": {
        "ansible_distribution": "\"debian\""
    }
}
```

With such input, [this][1] task will fail since it cannot match any condition. I've overwritten the `ansible_distribution` variable and dropped these second quotations.

[1]: https://github.com/marklee77/ansible-role-docker/blob/master/tasks/main.yml#L4