### PR TITLE
Fixes for ansible 2 compat. and CentOS 7 support.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1,4 +1,5 @@
 - hosts: all
-  sudo: True
+  become: False
+  become_user: root
   roles:
     - docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,26 +28,26 @@
 
 - name: ensure docker requirements packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
-  args: docker_package_info.args
-  with_items: docker_package_info.pre_pkgs
+  args: "{{ docker_package_info.args }}"
+  with_items: "{{ docker_package_info.pre_pkgs }}"
   when: docker_package_info.pre_pkgs|length > 0
 
 - name: ensure docker repository public key is installed
   action: "{{ docker_repo_key_info.pkg_key }}"
-  args: docker_repo_key_info.args
-  with_items: docker_repo_key_info.repo_keys
+  args: "{{ docker_repo_key_info.args }}"
+  with_items: "{{ docker_repo_key_info.repo_keys }}"
   when: docker_repo_key_info.repo_keys|length > 0
 
 - name: ensure docker repository is enabled
   action: "{{ docker_repo_info.pkg_repo }}"
-  args: docker_repo_info.args
-  with_items: docker_repo_info.repos
+  args: "{{ docker_repo_info.args }}"
+  with_items: "{{ docker_repo_info.repos }}"
   when: docker_repo_info.repos|length > 0
 
 - name: ensure docker packages are installed
   action: "{{ docker_package_info.pkg_mgr }}"
-  args: docker_package_info.args
-  with_items: docker_package_info.pkgs
+  args: "{{ docker_package_info.args }}"
+  with_items: "{{ docker_package_info.pkgs }}"
   when: docker_package_info.pkgs|length > 0
 
 - name: ensure docker service is started and enabled

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -1,0 +1,25 @@
+docker_kernel_min_version: '3.10.0-327'
+
+docker_package_info:
+  pkg_mgr: yum
+  args:
+      name: "{{ item }}"
+      state: latest
+      update_cache: yes
+  pre_pkgs:
+    - curl
+    - device-mapper-libs
+  pkgs:
+    - docker-latest
+
+docker_repo_key_info:
+  pkg_key: ''
+  args: {}
+  repo_keys: []
+
+docker_repo_info:
+  pkg_repo: ''
+  args: {}
+  repos: []
+
+docker_pip_path: /usr/bin/pip


### PR DESCRIPTION
Hi,

Some small fixes to get the role working on ansible 2.x, and a variable file for CentOS 7 based on the CentOS 6 version. Oh, I also updated the deploy.yml file to use become/become_user instead of the deprecated sudo.