### PR TITLE
Fix docker install with latest CentOS extras repo docker package.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
     enabled: yes
     state: started
   with_items:
-    - docker
+    - "{{ docker_package_info.pkgs }}"
 
 - name: ensure that pip is installed
   shell: curl -s https://bootstrap.pypa.io/get-pip.py | python -

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
     enabled: yes
     state: started
   with_items:
-    - "{{ docker_package_info.pkgs }}"
+    - "{{ docker_package_info.service_name }}"
 
 - name: ensure that pip is installed
   shell: curl -s https://bootstrap.pypa.io/get-pip.py | python -

--- a/vars/centos-6.yml
+++ b/vars/centos-6.yml
@@ -13,7 +13,7 @@ docker_package_info:
   pkgs:
     - docker-io
   service_name:
-    - "{{docker_package_info.pkgs}}"
+    - docker
 
 docker_repo_key_info:
   pkg_key: ''

--- a/vars/centos-6.yml
+++ b/vars/centos-6.yml
@@ -12,6 +12,8 @@ docker_package_info:
     - device-mapper-libs
   pkgs:
     - docker-io
+  service_name:
+    - "{{docker_package_info.pkgs}}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/vars/centos-7.yml
+++ b/vars/centos-7.yml
@@ -11,6 +11,8 @@ docker_package_info:
     - device-mapper-libs
   pkgs:
     - docker-latest
+  service_name:
+    - "{{docker_package_info.pkgs}}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -13,6 +13,8 @@ docker_package_info:
     - software-properties-common
   pkgs:
     - docker-engine
+  service_name:
+    - docker
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/vars/fedora-20.yml
+++ b/vars/fedora-20.yml
@@ -10,6 +10,8 @@ docker_package_info:
     - curl
   pkgs:
     - docker-io
+  service_name:
+    - "{{docker_package_info.pkgs}}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/vars/fedora-20.yml
+++ b/vars/fedora-20.yml
@@ -11,7 +11,7 @@ docker_package_info:
   pkgs:
     - docker-io
   service_name:
-    - "{{docker_package_info.pkgs}}"
+    - docker
 
 docker_repo_key_info:
   pkg_key: ''

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -10,6 +10,8 @@ docker_package_info:
     - curl
   pkgs:
     - docker
+  service_name:
+    - "{{docker_package_info.pkgs}}"  
 
 docker_repo_key_info:
   pkg_key: ''


### PR DESCRIPTION
Latest docker package from CentOS extras repository is now named docker-latest, and it doesn't provides _docker_, just _docker-latest_ so the task "ensure docker service is started and enabled " was failing as it was trying to enable _docker_ service instead of _docker-latest service_. 

Changing the item in task "ensure docker service is started and enabled " to use the package name from docker_package_info.pkgs instead of the hardcoded name fixes this.